### PR TITLE
Pipeline to run wercker-tests automatically using a cronjob

### DIFF
--- a/deployment/cronjob.template.yml
+++ b/deployment/cronjob.template.yml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: werckertests
 spec:
-  schedule: "*/1 * * * *" # minutely
+  schedule: "${SCHEDULE}" 
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5

--- a/deployment/cronjob.template.yml
+++ b/deployment/cronjob.template.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: werckertests
+spec:
+  schedule: "*/1 * * * *" # minutely
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 10
+  suspend: ${TPL_SUSPEND_JOB:-false}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: werckertests
+        spec:
+          nodeSelector:
+            ${NODE_SELECTOR}
+          containers:
+          - name: werckertest-runner
+            image: alpine
+            args:
+            - /bin/sh
+            - -c
+            - |
+              apk add curl
+              curl -H 'Authorization: Bearer ${WERCKER_TOKEN}' -H 'Content-Type: application/json' -d '{"pipelineId":"${PIPELINE}","message":"${MESSAGE} (`date -u`)"}' ${ENDPOINT}
+            resources:
+              requests:
+                cpu: 50m
+                memory: 25Mi
+              limits:
+                cpu: 500m
+                memory: 500Mi
+          restartPolicy: Never

--- a/deployment/cronjob.template.yml
+++ b/deployment/cronjob.template.yml
@@ -2,9 +2,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: werckertests
+  name: wercker-tests
 spec:
-  schedule: "${SCHEDULE}" 
+  schedule: "${TPL_SCHEDULE}" 
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5
@@ -15,10 +15,10 @@ spec:
       template:
         metadata:
           labels:
-            app: werckertests
+            app: wercker-tests
         spec:
           nodeSelector:
-            ${NODE_SELECTOR}
+            ${TPL_NODE_SELECTOR}
           containers:
           - name: werckertest-runner
             image: alpine
@@ -26,8 +26,8 @@ spec:
             - /bin/sh
             - -c
             - |
-              apk add curl
-              curl -H 'Authorization: Bearer ${WERCKER_TOKEN}' -H 'Content-Type: application/json' -d '{"pipelineId":"${PIPELINE}","message":"${MESSAGE} (`date -u`)"}' ${ENDPOINT}
+              apk --no-cache add curl
+              curl -H 'Authorization: Bearer ${TPL_WERCKER_TOKEN}' -H 'Content-Type: application/json' -d '{"pipelineId":"${TPL_PIPELINE}","message":"${TPL_MESSAGE} (`date -u`)"}' ${TPL_ENDPOINT}
             resources:
               requests:
                 cpu: 50m

--- a/wercker.yml
+++ b/wercker.yml
@@ -1104,16 +1104,17 @@ all-tests-passed:
         code: echo Dummy step
 
 # Deploy a cronjob to run these tests at a defined interval
-# deploy-kube requires the following environment variables to be set (some are used in deployment/cronjob.template.yml)
-# SCHEDULE - Cronjob schedule, for example 5 * * * *
+# deploy-kube requires the following environment variables to be set 
 # KUBERNETES_MASTER - Kubernetes master, of the form http://host:port
 # KUBERNETES_TOKEN - Token of a Kubernetes user that is allowed to deploy to Kubernetes 
-# WERCKER_TOKEN - Token of a Wercker user that is allowed to run the wercker-tests workflow
-# PIPELINE - Initial pipeline of the wercker-tests workflow
-# ENDPOINT- URL of API endpoint used to trigger a run of wercker-tests, for example https://dev.wercker.com/api/v3/runs 
-# MESSAGE - Comment string associated with the run. A timestamp will be appended to it.
+# (Env vars starting TPL_ are used in deployment/cronjob.template.yml)
+# TPL_SCHEDULE - Cronjob schedule, for example 5 * * * *
+# TPL_WERCKER_TOKEN - Token of a Wercker user that is allowed to run the wercker-tests workflow
+# TPL_PIPELINE - Initial pipeline of the wercker-tests workflow
+# TPL_ENDPOINT- URL of API endpoint used to trigger a run of wercker-tests, for example https://dev.wercker.com/api/v3/runs 
+# TPL_MESSAGE - Comment string associated with the run. A timestamp will be appended to it.
 # TPL_SUSPEND_JOB (optional) - Set to true to suspend further executions of the cronjob
-# NODE_SELECTOR (optional) - Set to a valid node selector, for example caste: patrician
+# TPL_NODE_SELECTOR (optional) - Set to a valid node selector, for example caste: patrician
 deploy-kube:
   box: alpine
   steps:

--- a/wercker.yml
+++ b/wercker.yml
@@ -1105,6 +1105,7 @@ all-tests-passed:
 
 # Deploy a cronjob to run these tests at a defined interval
 # deploy-kube requires the following environment variables to be set (some are used in deployment/cronjob.template.yml)
+# SCHEDULE - Cronjob schedule, for example 5 * * * *
 # KUBERNETES_MASTER - Kubernetes master, of the form http://host:port
 # KUBERNETES_TOKEN - Token of a Kubernetes user that is allowed to deploy to Kubernetes 
 # WERCKER_TOKEN - Token of a Wercker user that is allowed to run the wercker-tests workflow

--- a/wercker.yml
+++ b/wercker.yml
@@ -1111,7 +1111,7 @@ all-tests-passed:
 # WERCKER_TOKEN - Token of a Wercker user that is allowed to run the wercker-tests workflow
 # PIPELINE - Initial pipeline of the wercker-tests workflow
 # ENDPOINT- URL of API endpoint used to trigger a run of wercker-tests, for example https://dev.wercker.com/api/v3/runs 
-# MESSAGE - Comment string associated with the run. A timestamp will be appended.
+# MESSAGE - Comment string associated with the run. A timestamp will be appended to it.
 # TPL_SUSPEND_JOB (optional) - Set to true to suspend further executions of the cronjob
 # NODE_SELECTOR (optional) - Set to a valid node selector, for example caste: patrician
 deploy-kube:

--- a/wercker.yml
+++ b/wercker.yml
@@ -1102,3 +1102,28 @@ all-tests-passed:
     - script:
         name: Dummy step
         code: echo Dummy step  
+
+# Deploy a cronjob to run these tests at a defined interval
+# deploy-kube requires the following environment variables to be set (some are used in deployment/cronjob.template.yml)
+# KUBERNETES_MASTER - Kubernetes master, of the form http://host:port
+# KUBERNETES_TOKEN - Token of a Kubernetes user that is allowed to deploy to Kubernetes 
+# WERCKER_TOKEN - Token of a Wercker user that is allowed to run the wercker-tests workflow
+# PIPELINE - Initial pipeline of the wercker-tests workflow
+# ENDPOINT- URL of API endpoint used to trigger a run of wercker-tests, for example https://dev.wercker.com/api/v3/runs 
+# MESSAGE - Comment string associated with the run. A timestamp will be appended.
+# TPL_SUSPEND_JOB (optional) - Set to true to suspend further executions of the cronjob
+# NODE_SELECTOR (optional) - Set to a valid node selector, for example caste: patrician
+deploy-kube:
+  box: alpine
+  steps:
+    - bash-template:
+        # convert deployment/cronjob.template.yml to deployment/cronjob.yml, substituting environment variables
+        cwd: deployment     
+    - kubectl:
+        name: deploy to kubernetes
+        cwd: deployment
+        server: $KUBERNETES_MASTER
+        token: $KUBERNETES_TOKEN
+        insecure-skip-tls-verify: true
+        command: apply -f cronjob.yml --record=false # see https://github.com/kubernetes/kubernetes/issues/25554#issuecomment-269879971
+

--- a/wercker.yml
+++ b/wercker.yml
@@ -1101,7 +1101,7 @@ all-tests-passed:
   steps:
     - script:
         name: Dummy step
-        code: echo Dummy step  
+        code: echo Dummy step
 
 # Deploy a cronjob to run these tests at a defined interval
 # deploy-kube requires the following environment variables to be set (some are used in deployment/cronjob.template.yml)


### PR DESCRIPTION
This PR adds a new pipeline `deploy-kube` which creates a Kubernetes cronjob which runs the main `wercker-tests` test workflow periodically.

It is proposed that this be run hourly on both staging and production. 
