### PR TITLE
Change k8s apiVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ build --> test-docker-build1        --> test-docker-build2         Tests interna
           test-rdd-volumes2                                        Test the use of volumes with a RDD
 ```
 
+Each of the above sequences is followed by a fan-in to the `all-tests-passed` pipeline.
+
 The following environment variables must be set:
 * `USERNAME` - Any docker Hub username
 * `PASSWORD` - Any docker Hub password

--- a/deployment/cronjob.template.yml
+++ b/deployment/cronjob.template.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v2alpha1
 kind: CronJob
 metadata:
   name: wercker-tests

--- a/wercker.yml
+++ b/wercker.yml
@@ -1100,17 +1100,8 @@ all-tests-passed:
   box: alpine
   steps:
     - script:
-        name: Did the test pass?
-        code: |
-          echo WERCKER_RESULT=$WERCKER_RESULT
-          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-          echo WERCKER_FAILED_STEP_MESSAGE=$WERCKER_FAILED_STEP_MESSAGE
-  after-steps:
-    - slack-notifier:
-       url: $SLACK_URL
-       channel: #wercker-wercker-tests
-       username: werckerbot
-#       notify_on: "failed"
+        name: Dummy step
+        code: echo Dummy step
 
 # Deploy a cronjob to run these tests at a defined interval
 # deploy-kube requires the following environment variables to be set 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1100,8 +1100,17 @@ all-tests-passed:
   box: alpine
   steps:
     - script:
-        name: Dummy step
-        code: echo Dummy step
+        name: Did the test pass?
+        code: |
+          echo WERCKER_RESULT=$WERCKER_RESULT
+          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
+          echo WERCKER_FAILED_STEP_MESSAGE=$WERCKER_FAILED_STEP_MESSAGE
+  after-steps:
+    - slack-notifier:
+       url: $SLACK_URL
+       channel: #wercker-wercker-tests
+       username: werckerbot
+#       notify_on: "failed"
 
 # Deploy a cronjob to run these tests at a defined interval
 # deploy-kube requires the following environment variables to be set 


### PR DESCRIPTION
This PR changes the `apiVersion` used in `cronjob.template.yml` from `batch/v1beta1` (which worked fine with Docker for Mac but doesn't work in staging) to `batch/v2alpha1` (which matches what blackbox is currently configured to use for its cronjobs).

 