### PR TITLE
Send PagerDuty notifications if a test fails

### DIFF
--- a/bump.md
+++ b/bump.md
@@ -1,3 +1,3 @@
 Update this file and commit if you want to force a build. 
 
-Bump 2
+Bump 3

--- a/bump.md
+++ b/bump.md
@@ -1,3 +1,3 @@
 Update this file and commit if you want to force a build. 
 
-Bump 3
+Bump 4

--- a/bump.md
+++ b/bump.md
@@ -1,3 +1,3 @@
 Update this file and commit if you want to force a build. 
 
-Bump 4
+Bump 5

--- a/bump.md
+++ b/bump.md
@@ -1,3 +1,3 @@
 Update this file and commit if you want to force a build. 
 
-Bump 
+Bump 1 

--- a/bump.md
+++ b/bump.md
@@ -1,3 +1,3 @@
 Update this file and commit if you want to force a build. 
 
-Bump 5
+Bump

--- a/bump.md
+++ b/bump.md
@@ -1,3 +1,3 @@
 Update this file and commit if you want to force a build. 
 
-Bump
+Bump 

--- a/bump.md
+++ b/bump.md
@@ -1,3 +1,3 @@
 Update this file and commit if you want to force a build. 
 
-Bump 
+Bump 2

--- a/wercker.yml
+++ b/wercker.yml
@@ -100,8 +100,8 @@ build:
     - nigeldeakin/pagerduty-notifier@1.0.14:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
-        description: $DESCRIPTION
-
+        description: $PAGERDUTY_DESCRIPTION
+        branch: $PAGERDUTY_BRANCH
 test-docker-build1:
   # Test that we can run the docker-build step, test it using docker-run and then push it to a repo
   box: alpine:edge
@@ -150,24 +150,12 @@ test-docker-build1:
         password: $PASSWORD # Docker Hub password. When using CLI, set using "export X_PASSWORD=<password>" 
         repository: docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING
         tag: test-docker-build  
+  after-steps:
     - nigeldeakin/pagerduty-notifier@1.0.14:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
-        description: $DESCRIPTION
-  after-steps:
-    - script: 
-        name: After-step to display some env vars
-        code: |    
-          echo DEPLOY=$DEPLOY
-          echo WERCKER_DEPLOYTARGET_NAME=$WERCKER_DEPLOYTARGET_NAME
-          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
-          echo WERCKER_APPLICATION_NAME=$WERCKER_APPLICATION_NAME
-          echo WERCKER_STARTED_BY=$WERCKER_STARTED_BY
-          echo WERCKER_RESULT=$WERCKER_RESULT
-          echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
-          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME     
+        description: $PAGERDUTY_DESCRIPTION
+        branch: $PAGERDUTY_BRANCH
 test-docker-build2:
   # Test the docker-build step (part 2)
   # Test that we can pull the newly-created image, start it as a service, and connect to it

--- a/wercker.yml
+++ b/wercker.yml
@@ -97,6 +97,20 @@ build:
         code: |
           go test ./...     
   after-steps:
+    - script: 
+        name: Display some env vars
+        code: |    
+          echo DEPLOY=$DEPLOY
+          echo WERCKER_DEPLOYTARGET_NAME=$WERCKER_DEPLOYTARGET_NAME
+          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
+          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
+          echo WERCKER_APPLICATION_NAME=$WERCKER_APPLICATION_NAME
+          echo WERCKER_STARTED_BY=$WERCKER_STARTED_BY
+          echo WERCKER_RESULT=$WERCKER_RESULT
+          echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
+          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
+          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
+          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
     - nigeldeakin/pagerduty-notifier@1.0.0:
         service-key: wombatkey
 
@@ -147,7 +161,22 @@ test-docker-build1:
         username: $USERNAME # Docker Hub username. When using CLI, set using "export X_USERNAME=<username>"  
         password: $PASSWORD # Docker Hub password. When using CLI, set using "export X_PASSWORD=<password>" 
         repository: docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING
-        tag: test-docker-build       
+        tag: test-docker-build  
+  after-steps:
+    - script: 
+        name: Display some env vars
+        code: |    
+          echo DEPLOY=$DEPLOY
+          echo WERCKER_DEPLOYTARGET_NAME=$WERCKER_DEPLOYTARGET_NAME
+          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
+          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
+          echo WERCKER_APPLICATION_NAME=$WERCKER_APPLICATION_NAME
+          echo WERCKER_STARTED_BY=$WERCKER_STARTED_BY
+          echo WERCKER_RESULT=$WERCKER_RESULT
+          echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
+          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
+          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
+          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME     
 test-docker-build2:
   # Test the docker-build step (part 2)
   # Test that we can pull the newly-created image, start it as a service, and connect to it

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.6:
+    - nigeldeakin/pagerduty-notifier@1.0.7:
         service-key: wombatkey
 
 test-docker-build1:

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.9:
+    - nigeldeakin/pagerduty-notifier@1.0.10:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.1:
+    - nigeldeakin/pagerduty-notifier@1.0.2:
         service-key: wombatkey
 
 test-docker-build1:

--- a/wercker.yml
+++ b/wercker.yml
@@ -161,9 +161,22 @@ test-docker-build1:
         password: $PASSWORD # Docker Hub password. When using CLI, set using "export X_PASSWORD=<password>" 
         repository: docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING
         tag: test-docker-build  
-  after-steps:
     - script: 
         name: Display some env vars
+        code: |    
+          echo DEPLOY=$DEPLOY
+          echo WERCKER_DEPLOYTARGET_NAME=$WERCKER_DEPLOYTARGET_NAME
+          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
+          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
+          echo WERCKER_APPLICATION_NAME=$WERCKER_APPLICATION_NAME
+          echo WERCKER_STARTED_BY=$WERCKER_STARTED_BY
+          echo WERCKER_RESULT=$WERCKER_RESULT
+          echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
+          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
+          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME    
+  after-steps:
+    - script: 
+        name: After-step to display some env vars
         code: |    
           echo DEPLOY=$DEPLOY
           echo WERCKER_DEPLOYTARGET_NAME=$WERCKER_DEPLOYTARGET_NAME

--- a/wercker.yml
+++ b/wercker.yml
@@ -111,7 +111,8 @@ build:
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
     - nigeldeakin/pagerduty-notifier@1.0.7:
-        service-key: wombatkey
+        service-key: $PAGERDUTY_SERVICE_KEY
+        description: PLEASE IGNORE. This is a test by nigel.deakin@oracle.com.
 
 test-docker-build1:
   # Test that we can run the docker-build step, test it using docker-run and then push it to a repo

--- a/wercker.yml
+++ b/wercker.yml
@@ -112,7 +112,8 @@ build:
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
     - nigeldeakin/pagerduty-notifier@1.0.7:
         service_key: $PAGERDUTY_SERVICE_KEY
-        description: PLEASE IGNORE. This is a test by nigel.deakin@oracle.com.
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        description: $DESCRIPTION
 
 test-docker-build1:
   # Test that we can run the docker-build step, test it using docker-run and then push it to a repo

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.5:
+    - nigeldeakin/pagerduty-notifier@1.0.6:
         service-key: wombatkey
 
 test-docker-build1:

--- a/wercker.yml
+++ b/wercker.yml
@@ -74,6 +74,7 @@ build:
           echo `date +%s%N`-${PROD_OR_STAGING} > /pipeline/output/build-id
           export BUILDID=`cat /pipeline/output/build-id`
           echo BUILDID=$BUILDID
+          exit 1
     - script:    
         name: Check USERNAME variable
         # We also require PASSWORD to be set on those pipelines that require it (until we get WRKR-885 or WRKR-886)
@@ -109,7 +110,6 @@ build:
           echo WERCKER_RESULT=$WERCKER_RESULT
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
     - nigeldeakin/pagerduty-notifier@1.0.0:
         service-key: wombatkey
@@ -175,7 +175,6 @@ test-docker-build1:
           echo WERCKER_RESULT=$WERCKER_RESULT
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME     
 test-docker-build2:
   # Test the docker-build step (part 2)

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.0:
+    - nigeldeakin/pagerduty-notifier@1.0.1:
         service-key: wombatkey
 
 test-docker-build1:

--- a/wercker.yml
+++ b/wercker.yml
@@ -111,7 +111,7 @@ build:
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
     - nigeldeakin/pagerduty-notifier@1.0.7:
-        service-key: $PAGERDUTY_SERVICE_KEY
+        service_key: $PAGERDUTY_SERVICE_KEY
         description: PLEASE IGNORE. This is a test by nigel.deakin@oracle.com.
 
 test-docker-build1:

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.2:
+    - nigeldeakin/pagerduty-notifier@1.0.5:
         service-key: wombatkey
 
 test-docker-build1:

--- a/wercker.yml
+++ b/wercker.yml
@@ -95,13 +95,12 @@ build:
     - script: 
         name: Run the unit tests
         code: |
-          go test ./...                
+          go test ./... 
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.0.14:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
-        description: $PAGERDUTY_DESCRIPTION
-        branch: $PAGERDUTY_BRANCH
+        branch: $PAGERDUTY_BRANCH               
 test-docker-build1:
   # Test that we can run the docker-build step, test it using docker-run and then push it to a repo
   box: alpine:edge
@@ -151,10 +150,9 @@ test-docker-build1:
         repository: docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING
         tag: test-docker-build  
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.0.14:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
-        description: $PAGERDUTY_DESCRIPTION
         branch: $PAGERDUTY_BRANCH
 test-docker-build2:
   # Test the docker-build step (part 2)
@@ -193,7 +191,12 @@ test-docker-build2:
             else 
                 echo "Test failed: container did not respond"
                 exit 1
-            fi          
+            fi      
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH                
 test-docker-push-classic1:
   # Test the "classic" docker-push step (which commits the current container) (part 1) 
   box: golang
@@ -220,10 +223,10 @@ test-docker-push-classic1:
         cmd: /pipeline/source/myapp
         ports: "5000"
   after-steps:
-    - script:
-        name: The after step
-        code: |
-          echo "Running after step"           
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH         
 test-docker-push-classic2:
   # Test the "classic" docker-push step (which commits the current container) (part 2) 
   # Test that we can pull the newly-created image, start it and connect to it
@@ -261,7 +264,12 @@ test-docker-push-classic2:
             else 
                 echo "Test failed: container did not respond"
                 exit 1
-            fi     
+            fi    
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH 
 test-docker-scratch-push1:
   # Test the docker-scratch-push step (which copies the output to a scratch image) (part 1) 
   box: golang
@@ -285,6 +293,11 @@ test-docker-scratch-push1:
         tag: test-docker-scratch-push
         cmd: /myapp
         ports: "5000/tcp," 
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 test-docker-scratch-push2:
   # Test the docker-scratch-push step (which copies the output to a scratch image) (part 2) 
   # Test that we can pull the newly-created image, start it and connect to it
@@ -322,7 +335,12 @@ test-docker-scratch-push2:
             else 
                 echo "Test failed: container did not respond"
                 exit 1
-            fi                              
+            fi   
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH                           
 test-rdd1:
   # Test that we can use a remote docker daemon to build, run, test and push an image (part 1)
   box: alpine:edge
@@ -400,6 +418,11 @@ test-rdd1:
         code: |
           docker login -u $USERNAME -p $PASSWORD 
           docker push docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING:test-rdd
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 test-rdd2:
   # Test the image that was pushed by test-rdd1
   # Note that this uses a different daemon so this will require the image to be pulled from the registry
@@ -451,6 +474,11 @@ test-rdd2:
           docker kill container-test-rdd-$BUILDID
           echo running docker ps
           docker ps   
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 test-rdd-volumes1:
   # Test the use of bind mounts with a RDD
   box: alpine:edge
@@ -480,6 +508,11 @@ test-rdd-volumes1:
           # Start a container with the host's /tmp directory mounted as /foo
           # Within that container test to see whether the file we created in the other container exists
           docker run --entrypoint sh -i -v /tmp:/foo -e FILENAMETOTEST=/foo/$BUILDID alpine < script2.sh
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 test-rdd-volumes2:
   # Test the use of volumes with a RDD
   box: alpine:edge
@@ -527,6 +560,11 @@ test-rdd-volumes2:
         name: Remove the volume
         code: |
           docker volume rm vol-$BUILDID  
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 test-non-rdd-artifacts1:
   # Test that artifacts are passed correctly from one pipeline to the next in a non-rdd pipeline (when not using a RDD) (Part 1)
   box: alpine:edge
@@ -666,6 +704,11 @@ test-non-rdd-artifacts1:
         code: |
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 test-non-rdd-artifacts2:
   # Test that artifacts are passed correctly from one pipeline to the next in a non-rdd pipeline (when not using a RDD) (Part 1)
   box: alpine:edge
@@ -739,7 +782,12 @@ test-non-rdd-artifacts2:
           verify_directory `readlink -f $WERCKER_CACHE_DIR/symlinks/dir7`
           # verify the relative link to a file under $WERCKER_CACHE_DIR
           verify_symlink $WERCKER_CACHE_DIR/symlinks/file8 
-          verify_normal_file `readlink -f $WERCKER_CACHE_DIR/symlinks/file8`                
+          verify_normal_file `readlink -f $WERCKER_CACHE_DIR/symlinks/file8` 
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH               
 test-rdd-artifacts1:
   # Test that artifacts are passed correctly from one pipeline to the next when using a RDD (Part 1)
   box: alpine:edge
@@ -880,6 +928,11 @@ test-rdd-artifacts1:
         code: |
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 test-rdd-artifacts2:
   # Test that artifacts are passed correctly from one pipeline to the next when using a RDD (Part 2)
   box: alpine:edge
@@ -954,7 +1007,12 @@ test-rdd-artifacts2:
           verify_directory `readlink -f $WERCKER_CACHE_DIR/symlinks/dir7`
           # verify the relative link to a file under $WERCKER_CACHE_DIR
           verify_symlink $WERCKER_CACHE_DIR/symlinks/file8 
-          verify_normal_file `readlink -f $WERCKER_CACHE_DIR/symlinks/file8`                 
+          verify_normal_file `readlink -f $WERCKER_CACHE_DIR/symlinks/file8` 
+  after-steps:
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH                
 test-fn1:
   # Simple Fn use case in which we start the fn server (using docker in docker) and build, deploy and call a function
   box: alpine:edge
@@ -1029,7 +1087,11 @@ test-fn1:
         name: Clean up
         code: |
           # kill fn server (don't fail if there isn't one)
-          docker kill functions 2> /dev/null | true                   
+          docker kill functions 2> /dev/null | true      
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH             
 test-fn2:
   # Simple Fn use case in which we start the fn server (using the local docker rather than docker in docker) and build, deploy and call a function
   box: alpine:edge
@@ -1105,6 +1167,10 @@ test-fn2:
         code: |
           # kill fn server (don't fail if there isn't one)
           docker kill functions 2> /dev/null | true
+    - nigeldeakin/pagerduty-notifier@1.1.0:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH
 
 all-tests-passed:
   # This pipeline is dependent on all tests passing and is configured to report to SCM that the tests have passed

--- a/wercker.yml
+++ b/wercker.yml
@@ -97,9 +97,9 @@ build:
         code: |
           go test ./... 
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH               
 test-docker-build1:
   # Test that we can run the docker-build step, test it using docker-run and then push it to a repo
@@ -150,9 +150,9 @@ test-docker-build1:
         repository: docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING
         tag: test-docker-build  
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-docker-build2:
   # Test the docker-build step (part 2)
@@ -193,9 +193,9 @@ test-docker-build2:
                 exit 1
             fi      
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH                
 test-docker-push-classic1:
   # Test the "classic" docker-push step (which commits the current container) (part 1) 
@@ -223,9 +223,9 @@ test-docker-push-classic1:
         cmd: /pipeline/source/myapp
         ports: "5000"
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH         
 test-docker-push-classic2:
   # Test the "classic" docker-push step (which commits the current container) (part 2) 
@@ -266,9 +266,9 @@ test-docker-push-classic2:
                 exit 1
             fi    
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH 
 test-docker-scratch-push1:
   # Test the docker-scratch-push step (which copies the output to a scratch image) (part 1) 
@@ -294,9 +294,9 @@ test-docker-scratch-push1:
         cmd: /myapp
         ports: "5000/tcp," 
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-docker-scratch-push2:
   # Test the docker-scratch-push step (which copies the output to a scratch image) (part 2) 
@@ -337,9 +337,9 @@ test-docker-scratch-push2:
                 exit 1
             fi   
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH                           
 test-rdd1:
   # Test that we can use a remote docker daemon to build, run, test and push an image (part 1)
@@ -419,9 +419,9 @@ test-rdd1:
           docker login -u $USERNAME -p $PASSWORD 
           docker push docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING:test-rdd
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-rdd2:
   # Test the image that was pushed by test-rdd1
@@ -475,9 +475,9 @@ test-rdd2:
           echo running docker ps
           docker ps   
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-rdd-volumes1:
   # Test the use of bind mounts with a RDD
@@ -509,9 +509,9 @@ test-rdd-volumes1:
           # Within that container test to see whether the file we created in the other container exists
           docker run --entrypoint sh -i -v /tmp:/foo -e FILENAMETOTEST=/foo/$BUILDID alpine < script2.sh
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-rdd-volumes2:
   # Test the use of volumes with a RDD
@@ -561,9 +561,9 @@ test-rdd-volumes2:
         code: |
           docker volume rm vol-$BUILDID  
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-non-rdd-artifacts1:
   # Test that artifacts are passed correctly from one pipeline to the next in a non-rdd pipeline (when not using a RDD) (Part 1)
@@ -705,9 +705,9 @@ test-non-rdd-artifacts1:
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-non-rdd-artifacts2:
   # Test that artifacts are passed correctly from one pipeline to the next in a non-rdd pipeline (when not using a RDD) (Part 1)
@@ -784,9 +784,9 @@ test-non-rdd-artifacts2:
           verify_symlink $WERCKER_CACHE_DIR/symlinks/file8 
           verify_normal_file `readlink -f $WERCKER_CACHE_DIR/symlinks/file8` 
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH               
 test-rdd-artifacts1:
   # Test that artifacts are passed correctly from one pipeline to the next when using a RDD (Part 1)
@@ -929,9 +929,9 @@ test-rdd-artifacts1:
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 test-rdd-artifacts2:
   # Test that artifacts are passed correctly from one pipeline to the next when using a RDD (Part 2)
@@ -1009,9 +1009,9 @@ test-rdd-artifacts2:
           verify_symlink $WERCKER_CACHE_DIR/symlinks/file8 
           verify_normal_file `readlink -f $WERCKER_CACHE_DIR/symlinks/file8` 
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH                
 test-fn1:
   # Simple Fn use case in which we start the fn server (using docker in docker) and build, deploy and call a function
@@ -1088,9 +1088,9 @@ test-fn1:
         code: |
           # kill fn server (don't fail if there isn't one)
           docker kill functions 2> /dev/null | true      
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH             
 test-fn2:
   # Simple Fn use case in which we start the fn server (using the local docker rather than docker in docker) and build, deploy and call a function
@@ -1167,9 +1167,9 @@ test-fn2:
         code: |
           # kill fn server (don't fail if there isn't one)
           docker kill functions 2> /dev/null | true
-    - nigeldeakin/pagerduty-notifier@1.1.0:
-        service_key: $PAGERDUTY_SERVICE_KEY
-        notify_on: $PAGERDUTY_NOTIFY_ON
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH
 
 all-tests-passed:

--- a/wercker.yml
+++ b/wercker.yml
@@ -141,7 +141,9 @@ test-docker-build1:
             else 
                 echo "Test failed: container did not respond"
                 exit 1
-            fi           
+            fi   
+            ### fail!!!
+            exit 1        
     - internal/docker-kill:
         name: myTestContainer           
     - internal/docker-push:    

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.10:
+    - nigeldeakin/pagerduty-notifier@1.0.11:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION

--- a/wercker.yml
+++ b/wercker.yml
@@ -97,7 +97,7 @@ build:
         code: |
           go test ./...     
   after-steps:
-    - nigeldeakin/pagerduty-notifier@1.0.13:
+    - nigeldeakin/pagerduty-notifier@1.0.14:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION
@@ -150,7 +150,7 @@ test-docker-build1:
         password: $PASSWORD # Docker Hub password. When using CLI, set using "export X_PASSWORD=<password>" 
         repository: docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING
         tag: test-docker-build  
-    - nigeldeakin/pagerduty-notifier@1.0.13:
+    - nigeldeakin/pagerduty-notifier@1.0.14:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION

--- a/wercker.yml
+++ b/wercker.yml
@@ -96,6 +96,8 @@ build:
         name: Run the unit tests
         code: |
           go test ./...     
+    - nigeldeakin/pagerduty-notifier@1.0.0:
+        service-key: wombatkey
 
 test-docker-build1:
   # Test that we can run the docker-build step, test it using docker-run and then push it to a repo

--- a/wercker.yml
+++ b/wercker.yml
@@ -74,7 +74,6 @@ build:
           echo `date +%s%N`-${PROD_OR_STAGING} > /pipeline/output/build-id
           export BUILDID=`cat /pipeline/output/build-id`
           echo BUILDID=$BUILDID
-          exit 1
     - script:    
         name: Check USERNAME variable
         # We also require PASSWORD to be set on those pipelines that require it (until we get WRKR-885 or WRKR-886)

--- a/wercker.yml
+++ b/wercker.yml
@@ -95,7 +95,9 @@ build:
     - script: 
         name: Run the unit tests
         code: |
-          go test ./...     
+          go test ./...   
+          ### fail!!!
+          exit 1                
   after-steps:
     - nigeldeakin/pagerduty-notifier@1.0.14:
         service_key: $PAGERDUTY_SERVICE_KEY
@@ -141,9 +143,7 @@ test-docker-build1:
             else 
                 echo "Test failed: container did not respond"
                 exit 1
-            fi   
-            ### fail!!!
-            exit 1        
+            fi      
     - internal/docker-kill:
         name: myTestContainer           
     - internal/docker-push:    

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.7:
+    - nigeldeakin/pagerduty-notifier@1.0.8:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.8:
+    - nigeldeakin/pagerduty-notifier@1.0.9:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION

--- a/wercker.yml
+++ b/wercker.yml
@@ -110,7 +110,7 @@ build:
           echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
           echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
           echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.11:
+    - nigeldeakin/pagerduty-notifier@1.0.12:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION

--- a/wercker.yml
+++ b/wercker.yml
@@ -97,20 +97,7 @@ build:
         code: |
           go test ./...     
   after-steps:
-    - script: 
-        name: Display some env vars
-        code: |    
-          echo DEPLOY=$DEPLOY
-          echo WERCKER_DEPLOYTARGET_NAME=$WERCKER_DEPLOYTARGET_NAME
-          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
-          echo WERCKER_APPLICATION_NAME=$WERCKER_APPLICATION_NAME
-          echo WERCKER_STARTED_BY=$WERCKER_STARTED_BY
-          echo WERCKER_RESULT=$WERCKER_RESULT
-          echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
-          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME
-    - nigeldeakin/pagerduty-notifier@1.0.12:
+    - nigeldeakin/pagerduty-notifier@1.0.13:
         service_key: $PAGERDUTY_SERVICE_KEY
         notify_on: $PAGERDUTY_NOTIFY_ON
         description: $DESCRIPTION
@@ -163,19 +150,10 @@ test-docker-build1:
         password: $PASSWORD # Docker Hub password. When using CLI, set using "export X_PASSWORD=<password>" 
         repository: docker.io/$USERNAME/wercker-test-$PROD_OR_STAGING
         tag: test-docker-build  
-    - script: 
-        name: Display some env vars
-        code: |    
-          echo DEPLOY=$DEPLOY
-          echo WERCKER_DEPLOYTARGET_NAME=$WERCKER_DEPLOYTARGET_NAME
-          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_BUILD_URL=$WERCKER_BUILD_URL
-          echo WERCKER_APPLICATION_NAME=$WERCKER_APPLICATION_NAME
-          echo WERCKER_STARTED_BY=$WERCKER_STARTED_BY
-          echo WERCKER_RESULT=$WERCKER_RESULT
-          echo WERCKER_GIT_BRANCH=$WERCKER_GIT_BRANCH
-          echo WERCKER_DEPLOY_URL=$WERCKER_DEPLOY_URL
-          echo WERCKER_FAILED_STEP_DISPLAY_NAME=$WERCKER_FAILED_STEP_DISPLAY_NAME    
+    - nigeldeakin/pagerduty-notifier@1.0.13:
+        service_key: $PAGERDUTY_SERVICE_KEY
+        notify_on: $PAGERDUTY_NOTIFY_ON
+        description: $DESCRIPTION
   after-steps:
     - script: 
         name: After-step to display some env vars

--- a/wercker.yml
+++ b/wercker.yml
@@ -96,6 +96,7 @@ build:
         name: Run the unit tests
         code: |
           go test ./...     
+  after-steps:
     - nigeldeakin/pagerduty-notifier@1.0.0:
         service-key: wombatkey
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -95,9 +95,7 @@ build:
     - script: 
         name: Run the unit tests
         code: |
-          go test ./...   
-          ### fail!!!
-          exit 1                
+          go test ./...                
   after-steps:
     - nigeldeakin/pagerduty-notifier@1.0.14:
         service_key: $PAGERDUTY_SERVICE_KEY


### PR DESCRIPTION
This PR extends these tests to send PagerDuty notifications if a test fails.

This has been done by adding an after-step at the end of every pipeline that calls the `nigeldeakin/pagerduty-notifier` step.

To make these changes work, the following environment variables need to be set:

* `PAGERDUTY_NOTIFY_ON` needs to be set to `failed` (so we only get notifications when pipelines fail)
* `PAGERDUTY_BRANCH` needs to be set to `master`(so we only get notifications for runs on the main branch)
* `PAGERDUTY_SERVICE_KEY` needs to be set to an appropriate PagerDuty service key. This will send notifications to `#wercker-alerts` and `#wercker-alerts-stage` as appropriate.

Notes:

* We don't want users to fork this repo and add `echo` statements to dump out `PAGERDUTY_SERVICE_KEY`. This means that we may defer setting `PAGERDUTY_SERVICE_KEY` until https://jira.oraclecorp.com/jira/browse/WRKR-886 or https://jira.oraclecorp.com/jira/browse/WRKR-885 are done.

* The after-steps in those pipelines that (1) use alpine and (2) use the docker internal steps will not be run until https://jira.oraclecorp.com/jira/browse/WRKR-1050 is fixed. 

* In addition the notification will contain an invalid run URL until https://jira.oraclecorp.com/jira/browse/WRKR-1048 is fixed. 

However this PR can itself be merged safely without waiting for these issues to be fixed.