### PR TITLE
Fix failing fn tests by setting fn version

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -946,6 +946,7 @@ test-rdd-artifacts2:
           verify_normal_file `readlink -f $WERCKER_CACHE_DIR/symlinks/file8`                 
 test-fn1:
   # Simple Fn use case in which we start the fn server (using docker in docker) and build, deploy and call a function
+  # This uses an old but fixed version of Fn.
   box: alpine:edge
   docker: true
   steps:
@@ -962,14 +963,14 @@ test-fn1:
         name: Start fn server (using DinD)
         code: |
           docker ps
-          docker run --privileged -d --rm --name functions --network=$DOCKER_NETWORK_NAME -v $PWD/data:/app/data -p 8080:8080 fnproject/fnserver 
+          docker run --privileged -d --rm --name functions --network=$DOCKER_NETWORK_NAME -v $PWD/data:/app/data -p 8080:8080 fnproject/fnserver:0.3.562 
           # need to allow time for the fn server to start - the next step is slow which should give it enough time
     - script:
         name: Install fn CLI (do this once for all the fn pipelines)
         code: |
           mkdir $WERCKER_ROOT/fn
           cd $WERCKER_ROOT/fn
-          wget --no-verbose https://github.com/fnproject/cli/releases/download/0.4.117/fn_alpine  # need to replace with a URI to the latest version
+          wget --no-verbose https://github.com/fnproject/cli/releases/download/0.4.117/fn_alpine  
           mv fn_alpine fn
           chmod a+x $WERCKER_ROOT/fn/fn 
           export PATH=$WERCKER_ROOT/fn:$PATH
@@ -1021,6 +1022,7 @@ test-fn1:
           docker kill functions 2> /dev/null | true                   
 test-fn2:
   # Simple Fn use case in which we start the fn server (using the local docker rather than docker in docker) and build, deploy and call a function
+  # This uses an old but fixed version of Fn.
   box: alpine:edge
   docker: true
   steps:
@@ -1037,14 +1039,14 @@ test-fn2:
         name: Start fn server (using local docker, not using DinD)
         code: |
           docker ps
-          docker run -d --rm --name functions --network=$DOCKER_NETWORK_NAME -e FN_DOCKER_NETWORKS=$DOCKER_NETWORK_NAME -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/data:/app/data -p 8080:8080 fnproject/fnserver 
+          docker run -d --rm --name functions --network=$DOCKER_NETWORK_NAME -e FN_DOCKER_NETWORKS=$DOCKER_NETWORK_NAME -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/data:/app/data -p 8080:8080 fnproject/fnserver:0.3.562 
           # need to allow time for the fn server to start - the next step is slow which should give it enough time
     - script:
         name: Install fn CLI 
         code: |
           mkdir $WERCKER_ROOT/fn
           cd $WERCKER_ROOT/fn
-          wget --no-verbose https://github.com/fnproject/cli/releases/download/0.4.117/fn_alpine  # need to replace with a URI to the latest version
+          wget --no-verbose https://github.com/fnproject/cli/releases/download/0.4.117/fn_alpine  
           mv fn_alpine fn
           chmod a+x $WERCKER_ROOT/fn/fn 
           export PATH=$WERCKER_ROOT/fn:$PATH


### PR DESCRIPTION
The Fn tests have started failing because they use the latest `fnserver` image but a fixed version of the CLI (`fn`), and the two became incompatible yesterday. 

This PR fixes the image version so that it is compatible with the fixed CLI version. Both versions are fairly old, and at some point (not not right now) we should update the test to work with the latest version of Fn.

