### PR TITLE
Remove misleading timestamp from the comment used for automated runs

### DIFF
--- a/deployment/cronjob.template.yml
+++ b/deployment/cronjob.template.yml
@@ -27,7 +27,7 @@ spec:
             - -c
             - |
               apk --no-cache add curl
-              curl -H 'Authorization: Bearer ${TPL_WERCKER_TOKEN}' -H 'Content-Type: application/json' -d '{"pipelineId":"${TPL_PIPELINE}","message":"${TPL_MESSAGE} (`date -u`)"}' ${TPL_ENDPOINT}
+              curl -H 'Authorization: Bearer ${TPL_WERCKER_TOKEN}' -H 'Content-Type: application/json' -d '{"pipelineId":"${TPL_PIPELINE}","message":"${TPL_MESSAGE}"}' ${TPL_ENDPOINT}
             resources:
               requests:
                 cpu: 50m

--- a/wercker.yml
+++ b/wercker.yml
@@ -907,6 +907,7 @@ test-non-rdd-artifacts1:
         code: |
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
+  after-steps:
     - nigeldeakin/pagerduty-notifier:
         service-key: $PAGERDUTY_SERVICE_KEY
         notify-on: $PAGERDUTY_NOTIFY_ON

--- a/wercker.yml
+++ b/wercker.yml
@@ -907,28 +907,6 @@ test-non-rdd-artifacts1:
         code: |
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
-    - script:
-        name: Create a file in /tmp  
-        code: |
-          touch /tmp/foobarfoo  
-  after-steps:
-    - script:
-        name: Examine the file system
-        code: |
-          echo WERCKER_ROOT=$WERCKER_ROOT
-          echo ls -l $WERCKER_ROOT
-          ls -l $WERCKER_ROOT
-          echo WERCKER_SOURCE_DIR=$WERCKER_SOURCE_DIR
-          echo ls -l $WERCKER_SOURCE_DIR
-          ls -l $WERCKER_SOURCE_DIR
-          echo WERCKER_CACHE_DIR=$WERCKER_CACHE_DIR
-          echo ls -l $WERCKER_CACHE_DIR
-          ls -l $WERCKER_CACHE_DIR   
-          echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
-          echo ls -l $WERCKER_REPORT_ARTIFACTS_DIR
-          ls -l $WERCKER_REPORT_ARTIFACTS_DIR        
-          echo ls -l /tmp
-          ls -l /tmp      
     - nigeldeakin/pagerduty-notifier:
         service-key: $PAGERDUTY_SERVICE_KEY
         notify-on: $PAGERDUTY_NOTIFY_ON

--- a/wercker.yml
+++ b/wercker.yml
@@ -910,11 +910,7 @@ test-non-rdd-artifacts1:
     - script:
         name: Create a file in /tmp  
         code: |
-          touch /tmp/foobarfoo
-    - script:
-        name: Create a file in /scratch  
-        code: |
-          touch /scratch/scratchmyback      
+          touch /tmp/foobarfoo  
   after-steps:
     - script:
         name: Examine the file system
@@ -932,9 +928,7 @@ test-non-rdd-artifacts1:
           echo ls -l $WERCKER_REPORT_ARTIFACTS_DIR
           ls -l $WERCKER_REPORT_ARTIFACTS_DIR        
           echo ls -l /tmp
-          ls -l /tmp
-          echo ls -l /scratch
-          ls -l /scratch          
+          ls -l /tmp      
     - nigeldeakin/pagerduty-notifier:
         service-key: $PAGERDUTY_SERVICE_KEY
         notify-on: $PAGERDUTY_NOTIFY_ON

--- a/wercker.yml
+++ b/wercker.yml
@@ -908,6 +908,17 @@ test-non-rdd-artifacts1:
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
   after-steps:
+    - script:
+        name: Examine the file system
+        code: |
+          echo WERCKER_ROOT=$WERCKER_ROOT
+          echo ls -l $WERCKER_ROOT
+          echo WERCKER_SOURCE_DIR=$WERCKER_SOURCE_DIR
+          echo ls -l $WERCKER_SOURCE_DIR
+          echo WERCKER_CACHE_DIR=$WERCKER_CACHE_DIR
+          echo ls -l $WERCKER_CACHE_DIR   
+          echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
+          echo ls -l $WERCKER_REPORT_ARTIFACTS_DIR        
     - nigeldeakin/pagerduty-notifier:
         service-key: $PAGERDUTY_SERVICE_KEY
         notify-on: $PAGERDUTY_NOTIFY_ON

--- a/wercker.yml
+++ b/wercker.yml
@@ -911,6 +911,10 @@ test-non-rdd-artifacts1:
         name: Create a file in /tmp  
         code: |
           touch /tmp/foobarfoo
+    - script:
+        name: Create a file in /scratch  
+        code: |
+          touch /scratch/scratchmyback      
   after-steps:
     - script:
         name: Examine the file system
@@ -923,12 +927,14 @@ test-non-rdd-artifacts1:
           ls -l $WERCKER_SOURCE_DIR
           echo WERCKER_CACHE_DIR=$WERCKER_CACHE_DIR
           echo ls -l $WERCKER_CACHE_DIR
-          $WERCKER_CACHE_DIR   
+          ls -l $WERCKER_CACHE_DIR   
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           echo ls -l $WERCKER_REPORT_ARTIFACTS_DIR
           ls -l $WERCKER_REPORT_ARTIFACTS_DIR        
           echo ls -l /tmp
           ls -l /tmp
+          echo ls -l /scratch
+          ls -l /scratch          
     - nigeldeakin/pagerduty-notifier:
         service-key: $PAGERDUTY_SERVICE_KEY
         notify-on: $PAGERDUTY_NOTIFY_ON

--- a/wercker.yml
+++ b/wercker.yml
@@ -907,18 +907,28 @@ test-non-rdd-artifacts1:
         code: |
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
           touch $WERCKER_REPORT_ARTIFACTS_DIR/reportfile 
+    - script:
+        name: Create a file in /tmp  
+        code: |
+          touch /tmp/foobarfoo
   after-steps:
     - script:
         name: Examine the file system
         code: |
           echo WERCKER_ROOT=$WERCKER_ROOT
           echo ls -l $WERCKER_ROOT
+          ls -l $WERCKER_ROOT
           echo WERCKER_SOURCE_DIR=$WERCKER_SOURCE_DIR
           echo ls -l $WERCKER_SOURCE_DIR
+          ls -l $WERCKER_SOURCE_DIR
           echo WERCKER_CACHE_DIR=$WERCKER_CACHE_DIR
-          echo ls -l $WERCKER_CACHE_DIR   
+          echo ls -l $WERCKER_CACHE_DIR
+          $WERCKER_CACHE_DIR   
           echo WERCKER_REPORT_ARTIFACTS_DIR=$WERCKER_REPORT_ARTIFACTS_DIR
-          echo ls -l $WERCKER_REPORT_ARTIFACTS_DIR        
+          echo ls -l $WERCKER_REPORT_ARTIFACTS_DIR
+          ls -l $WERCKER_REPORT_ARTIFACTS_DIR        
+          echo ls -l /tmp
+          ls -l /tmp
     - nigeldeakin/pagerduty-notifier:
         service-key: $PAGERDUTY_SERVICE_KEY
         notify-on: $PAGERDUTY_NOTIFY_ON


### PR DESCRIPTION
This PR changes the deployment template used by the `deploy-kube` pipeline. This pipeline created a cronjob which runs these tests every hour.

Previously these runs had a run comment such as `Run triggered by crontab (Wed Sep 12 14:16:36 UTC 2018)`, where the timestamp is the time when the cronjob was deployed. This timestamp isn't particularly useful and has been found to confuse people. 

This PR removes that timestamp and changes the run comment to `Run triggered by crontab`. 

Tested in staging. See https://dev.wercker.com/wercker/wercker-tests/runs