### PR TITLE
Add new tests for pushing to OCIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,28 @@ Each of the above sequences is followed by a fan-in to the `all-tests-passed` pi
 
 The following environment variables must be set:
 
-* `USERNAME` - Any docker Hub username
-* `PASSWORD` - Any docker Hub password
 * `PROD_OR_STAGING` - A string used to distinguish between any workflows that might be run concurrently using the same username. This is appended to any image tags that are created in order to avoid name clashes on Docker Hub. Use lower case characters only. 
 
-The following environment variables are optional.  They can be used to configure pagerduty notifications.
+For tests that use Docker Hub:
+
+* `USERNAME` - Any Docker Hub username
+* `PASSWORD` - Docker Hub password for $USERNAME
+
+For tests that use Amazon ECR:
+
+* `AWS_REGION` - AWS region (for example `us-east-2`)
+* `AWS_ACCESS_KEY_ID` - AWS access key
+* `AWS_SECRET_ACCESS_KEY` - AWS secret access key
+* `ECR_REGISTRY` - ECR registry. For example https://<aws_account_id>.dkr.ecr.<region>.amazonaws.com for the AWS defaiult registry.
+
+For tests that use Oracle Cloud Infrastructure Registry (OCIR):
+
+* `OCI_REGION` - OCI region (for example `iad`)
+* `OCI_TENANCY_NAME` - OCI tenancy
+* `OCIR_USERNAME` - OCI username, in the form $OCI_TENANCY_NAME/foo@bar.com
+* `OCIR_AUTH_TOKEN` - OCI auth token for $OCIR_USERNAME
+
+The following environment variables are optional.  They can be used to configure pagerduty notifications:
 
 * `PAGERDUTY_SERVICE_KEY` - PagerDuty service key that defines the notification will be sent to. If not set then the notification after-step will fail harmlessly.
 * `PAGERDUTY_NOTIFY_ON` - Leave unset or set to `failed` to send notifications when the pipeline fails. Set to anything else (such as `all`) to send pagerduty notifications when the pipeline passes as well.
@@ -42,6 +59,16 @@ You can run these tests locally using the Wercker CLI. To do this, clone this re
 export X_USERNAME=<username>
 export X_PASSWORD=<password>
 export X_PROD_OR_STAGING=dev
+
+export X_AWS_REGION=<aws-region>
+export X_AWS_ACCESS_KEY_ID=<aws-access-key>
+export X_AWS_SECRET_ACCESS_KEY=<aws-secret-access-key>
+export X_ECR_REGISTRY=<ecr-registry>
+
+export X_OCI_REGION=<region>
+export X_OCI_TENANCY_NAME=<oci-tenancy>
+export X_OCIR_USERNAME=<oci-username>
+export X_OCIR_AUTH_TOKEN=<oci-auth-token>
 ```
 then navigate to the root directory of your cloned repository and run
 ```

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,13 +1,13 @@
 workflows:
-  - name: test-docker-build-ecr
+  - name: test-docker-build-ocir
     pipelines:
       - name: build
-      - name: test-docker-build-ecr-1
+      - name: test-docker-build-ocir-1
         requires:
           - build
-      - name: test-docker-build-ecr-2
+      - name: test-docker-build-ocir-2
         requires:
-          - test-docker-build-ecr-1        
+          - test-docker-build-ocir-1        
   - name: tests
     pipelines:
       - name: build
@@ -390,6 +390,144 @@ test-docker-build-ecr-2:
         service-key: $PAGERDUTY_SERVICE_KEY
         notify-on: $PAGERDUTY_NOTIFY_ON
         branch: $PAGERDUTY_BRANCH   
+
+test-docker-build-ocir-1:
+  # This is part 1 of a two-part test, and should be followed by test-docker-build-ocir-2
+  # Test that we can run the docker-build step, test it using docker-run and then push it to an Oracle Cloud Infrastructure Registry (OCIR) repo
+  # This pipeline requires the following environment variables to be set:
+  #   OCI_REGION (e.g. iad, fra, lhr, phx)
+  #   OCI_TENANCY_NAME
+  #   OCIR_USERNAME (e.g. $OCI_TENANCY_NAME/foo@bar.com)
+  #   OCIR_AUTH_TOKEN
+  #   PAGERDUTY_SERVICE_KEY, PAGERDUTY_NOTIFY_ON, PAGERDUTY_BRANCH  
+  # Optional environment variables
+  #   PROD_OR_STAGING - set to a string to avoid repository name clashes between concurrent builds on prod and staging 
+  box: python
+  steps:
+    
+    - script:
+        name: Get the a unique id for the run, common to all pipelines in the workflow
+        code: |
+          export BUILDID=`cat /pipeline/source/build-id`
+          echo BUILDID=$BUILDID
+          echo Copy build-id to /pipeline/output for any subsequent pipeline to use
+          cp /pipeline/source/build-id /pipeline/output  
+    - internal/docker-build: 
+        dockerfile: Dockerfile 
+        image-name: my-new-image # name used to refer to this image until it's pushed   
+    - internal/docker-run:
+        image: my-new-image
+        name: myTestContainer
+    - script: 
+        name: Wait for container to start 
+        code: | 
+          until $(curl --output /dev/null --silent --head --fail http://myTestContainer:5000); do printf '.'; sleep 5; done        
+    - script: 
+        name: Test the container that we started using docker-run
+        code: |
+            if curlOutput=`curl -s myTestContainer:5000`; then 
+                export expected="Hello World!! $BUILDID"
+                if [ "$curlOutput" == "$expected" ]; then
+                    echo "Test passed: container gave expected response: " $expected
+                else
+                    echo "Test failed: container gave unexpected response: " $curlOutput
+                    echo "The expected response was: " $expected
+                    exit 1
+                fi   
+            else 
+                echo "Test failed: container did not respond"
+                exit 1
+            fi      
+    - internal/docker-kill:
+        name: myTestContainer    
+    - script:
+        name: Construct OCIR registry name 
+        code: |
+          export OCIR_REGISTRY_NAME=https://$OCI_REGION.ocir.io/v2
+          echo OCIR_REGISTRY_NAME=$OCIR_REGISTRY_NAME
+    - script:
+        name: Construct OCIR repository name 
+        code: |
+          # Note that we convert PROD_OR_STAGING to lower case
+          export OCIR_REPOSITORY_NAME=$OCI_REGION.ocir.io/$OCI_TENANCY_NAME/wercker-tests/test-docker-build-ocir${PROD_OR_STAGING,,}
+          echo OCIR_REPOSITORY_NAME=$OCIR_REPOSITORY_NAME
+    - internal/docker-push:    
+        image-name: my-new-image
+        username: $OCIR_USERNAME 
+        password: $OCIR_AUTH_TOKEN 
+        repository: $OCIR_REPOSITORY_NAME
+        registry: $OCIR_REGISTRY_NAME
+        tag: latest  
+#  after-steps:
+#    - nigeldeakin/pagerduty-notifier:
+#        service-key: $PAGERDUTY_SERVICE_KEY
+#        notify-on: $PAGERDUTY_NOTIFY_ON
+#        branch: $PAGERDUTY_BRANCH    
+test-docker-build-ocir-2:
+  # This is part 2 of a two-part test, and must follow after test-docker-build-ocir-1
+  # Test that we can pull the image that the preceding pipeline created in an Oracle Cloud Infrastructure Registry (OCIR) repo, start it using internal/docker-run, and connect to it
+  # This pipeline requires the following environment variables to be set:
+  #   OCI_REGION (e.g. iad, fra, lhr, phx)
+  #   OCI_TENANCY_NAME
+  #   OCIR_USERNAME (e.g. $OCI_TENANCY_NAME/foo@bar.com)
+  #   OCIR_AUTH_TOKEN
+  #   PAGERDUTY_SERVICE_KEY, PAGERDUTY_NOTIFY_ON, PAGERDUTY_BRANCH  
+  # Optional environment variables
+  #   PROD_OR_STAGING - must match whatever was set for test-docker-build-ocir-1 
+
+  box: python
+  steps:
+    - script:
+        name: Get the a unique id for the run, common to all pipelines in the workflow
+        code: |
+          export BUILDID=`cat /pipeline/source/build-id`
+          echo BUILDID=$BUILDID
+          echo Copy build-id to /pipeline/output for any subsequent pipeline to use
+          cp /pipeline/source/build-id /pipeline/output   
+    - script:
+        name: Construct OCIR registry name 
+        code: |
+          export OCIR_REGISTRY_NAME=https://$OCI_REGION.ocir.io
+          echo OCIR_REGISTRY_NAME=$OCIR_REGISTRY_NAME          
+    - script:
+        name: Construct OCIR repository name 
+        code: |
+          # Note that we convert PROD_OR_STAGING to lower case
+          export OCIR_REPOSITORY_NAME=$OCI_REGION.ocir.io/$OCI_TENANCY_NAME/wercker-tests/test-docker-build-ocir${PROD_OR_STAGING,,}
+          echo OCIR_REPOSITORY_NAME=$OCIR_REPOSITORY_NAME    
+          echo $OCIR_REGISTRY_NAME/$OCIR_REPOSITORY_NAME:latest   
+    - internal/docker-run:
+        image: $OCIR_REPOSITORY_NAME:latest
+        username: $OCIR_USERNAME 
+        password: $OCIR_AUTH_TOKEN 
+        name: myTestContainer
+    - script: 
+        name: Wait for container to start 
+        code: | 
+          until $(curl --output /dev/null --silent --head --fail http://myTestContainer:5000); do printf '.'; sleep 5; done        
+    - script: 
+        name: Test the container that we started using docker-run
+        code: |
+            if curlOutput=`curl -s myTestContainer:5000`; then 
+                export expected="Hello World!! $BUILDID"
+                if [ "$curlOutput" == "$expected" ]; then
+                    echo "Test passed: container gave expected response: " $expected
+                else
+                    echo "Test failed: container gave unexpected response: " $curlOutput
+                    echo "The expected response was: " $expected
+                    exit 1
+                fi   
+            else 
+                echo "Test failed: container did not respond"
+                exit 1
+            fi      
+    - internal/docker-kill:
+        name: myTestContainer  
+#  after-steps:
+#    - nigeldeakin/pagerduty-notifier:
+#        service-key: $PAGERDUTY_SERVICE_KEY
+#        notify-on: $PAGERDUTY_NOTIFY_ON
+#        branch: $PAGERDUTY_BRANCH   
 
 test-docker-push-classic1:
   # Test the "classic" docker-push step (which commits the current container) (part 1) 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,13 +1,4 @@
-workflows:
-  - name: test-docker-build-ocir
-    pipelines:
-      - name: build
-      - name: test-docker-build-ocir-1
-        requires:
-          - build
-      - name: test-docker-build-ocir-2
-        requires:
-          - test-docker-build-ocir-1        
+workflows:   
   - name: tests
     pipelines:
       - name: build
@@ -69,6 +60,20 @@ workflows:
       - name: test-rdd-volumes2
         requires:
           - build
+      #
+      - name: test-docker-build-ecr-1
+        requires:
+          - build
+      - name: test-docker-build-ecr-2
+        requires:
+          - test-docker-build-ecr-1    
+      # 
+      - name: test-docker-build-ocir-1
+        requires:
+          - build
+      - name: test-docker-build-ocir-2
+        requires:
+          - test-docker-build-ocir-1   
 
 build: 
   # The build step doesn't do very much 
@@ -458,11 +463,11 @@ test-docker-build-ocir-1:
         repository: $OCIR_REPOSITORY_NAME
         registry: $OCIR_REGISTRY_NAME
         tag: latest  
-#  after-steps:
-#    - nigeldeakin/pagerduty-notifier:
-#        service-key: $PAGERDUTY_SERVICE_KEY
-#        notify-on: $PAGERDUTY_NOTIFY_ON
-#        branch: $PAGERDUTY_BRANCH    
+  after-steps:
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH    
 test-docker-build-ocir-2:
   # This is part 2 of a two-part test, and must follow after test-docker-build-ocir-1
   # Test that we can pull the image that the preceding pipeline created in an Oracle Cloud Infrastructure Registry (OCIR) repo, start it using internal/docker-run, and connect to it
@@ -523,11 +528,11 @@ test-docker-build-ocir-2:
             fi      
     - internal/docker-kill:
         name: myTestContainer  
-#  after-steps:
-#    - nigeldeakin/pagerduty-notifier:
-#        service-key: $PAGERDUTY_SERVICE_KEY
-#        notify-on: $PAGERDUTY_NOTIFY_ON
-#        branch: $PAGERDUTY_BRANCH   
+  after-steps:
+    - nigeldeakin/pagerduty-notifier:
+        service-key: $PAGERDUTY_SERVICE_KEY
+        notify-on: $PAGERDUTY_NOTIFY_ON
+        branch: $PAGERDUTY_BRANCH   
 
 test-docker-push-classic1:
   # Test the "classic" docker-push step (which commits the current container) (part 1) 


### PR DESCRIPTION
This PR adds a new test case that tests the use of `internal/docker-push` to push an image to OCIR, and the use of `internal/docker-run` to pull and run a (private) image that is on OCIR.

Example run at https://app.wercker.com/wercker/wercker-tests/runs/build/5c2f92ae0518260007ad8809?step=5c2f92c1cfa0fc00074f6995